### PR TITLE
Add Milestone for Select Translations MVP

### DIFF
--- a/burnup/index.html
+++ b/burnup/index.html
@@ -32,7 +32,7 @@
     </style>
 
     <script>
-      window.CHART_START_DATE = "2023-02-01"
+      window.CHART_START_DATE = "2023-01-01"
     </script>
 
     <!-- C3/D3 -->

--- a/burnup/js/burndown.js
+++ b/burnup/js/burndown.js
@@ -28,7 +28,7 @@
     function months(m) { return weeks(4 * m); }
 
     const queryString = window.CHART_QUERY_STRING || getQueryString();
-    const chartStartDate = window.CHART_START_DATE || getChartStartDate();
+    const chartStartDate = getChartStartDate();
 
     function getQueryString() {
         // e.g. "?foo=bar&baz=qux&/"
@@ -44,6 +44,7 @@
       const CHART_START_PERIOD = months(4);
       const searchParams = parseQueryString(queryString);
       return (searchParams && searchParams.since) ||
+             window.CHART_START_DATE ||
              yyyy_mm_dd(new Date(Date.now() - CHART_START_PERIOD));
 
       function parseQueryString(qs) {

--- a/index.html
+++ b/index.html
@@ -12,28 +12,6 @@
   <div class="milestones">
     <div class="desc-box-outer">
       <div class="desc-box">
-        <h2>Desktop MVP H1 2023</h2>
-        <p>
-          This chart tracks the MVP for Firefox Translations on Desktop.
-          <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1820214">Bug 1820214</a>
-        </p>
-        <p>
-          A <a href="https://docs.google.com/spreadsheets/d/1RPuaGSNFnOoWqaWU4cIseupMCNqp4l3aTOhaipxn89k/edit#gid=921073691">
-            spreadsheet breakdown of these bugs</a> is available.
-        </p>
-      </div>
-    </div>
-
-    <div style="width: 70%" class="iframe-container">
-      <div>
-          <iframe src="./burnup/?blocks=1820214&priority=P1&priority=P2&priority=P3"></iframe>
-      </div>
-    </div>
-  </div>
-
-  <div class="milestones">
-    <div class="desc-box-outer">
-      <div class="desc-box">
         <h2>Firefox Translations</h2>
         <p>
           This chart tracks the overall translations work in the Firefox Translations component.
@@ -45,36 +23,50 @@
 
     <div style="width: 70%" class="iframe-container">
       <div>
-          <iframe src="./burnup/?priority=P1&priority=P2&priority=P3&product=Firefox&component=Translation"></iframe>
+          <iframe src="./burnup/index.html?priority=P1&priority=P2&priority=P3&product=Firefox&component=Translation"></iframe>
       </div>
     </div>
   </div>
 
+  <h1>Ongoing Work</h1>
+
+
   <div class="milestones">
     <div class="desc-box-outer">
       <div class="desc-box">
-        <h2>Android MVP (TODO)</h2>
+        <h2>Select Translations MVP</h2>
         <p>
-          This chart tracks the MVP for Firefox Translations on Android. This chart is
-          only for specific Android features, and assumes completion of the Desktop
-          chart.
-          <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1820240">Bug 1820240</a>
-        </p>
+          This chart tracks the MVP for Firefox Select Translations on Firefox Desktop.
+          <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1855907">Bug 1855907</a>
+      </div>
+    </div>
+
+    <div style="width: 70%" class="iframe-container">
+      <div>
+          <iframe src="./burnup/index.html?since=2023-11-01&blocks=1855907&priority=P1&priority=P2&priority=P3"></iframe>
+      </div>
+    </div>
+  </div>
+
+  <h1>Completed Work</h1>
+
+  <div class="milestones">
+    <div class="desc-box-outer">
+      <div class="desc-box">
+        <h2>Desktop MVP H1 2023</h2>
         <p>
-          A <a href="https://docs.google.com/spreadsheets/d/1RPuaGSNFnOoWqaWU4cIseupMCNqp4l3aTOhaipxn89k/edit#gid=1626758562">
-            spreadsheet breakdown of these bugs</a> is available.
+          This chart tracks the MVP for Full-Page Translations on Firefox Desktop.
+          <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1820214">Bug 1820214</a>
         </p>
       </div>
     </div>
 
     <div style="width: 70%" class="iframe-container">
       <div>
-          <iframe src="./burnup/?blocks=1820240&priority=P1&priority=P2&priority=P3"></iframe>
+          <iframe src="./burnup/index.html?blocks=1820214&priority=P1&priority=P2&priority=P3"></iframe>
       </div>
     </div>
   </div>
-
-
 
   <div class="summary-box">
     <hr />


### PR DESCRIPTION
- Fixes a bug where the start date was not respecting the `since` attribute in the query string parameters because it was always checking for `window.CHART_START_DATE` first, which is statically defined in the HTML and always present. This means it was always ignoring the query string because it always had a value to take.

- Updates the statically defined default start date to be Jan. 01 2023 from Feb. 01 2023

- Removes the TODO Android milestone from the main page.

- Adds a milestone for the Select Translations MVP to the main page.

- Separates main page into sections of completed work and ongoing work.